### PR TITLE
Changed the method of fetching item contents to innerText

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -470,7 +470,8 @@ List.prototype.templateEngines.standard = function(list, settings) {
         ensure.created(item);
         var values = {};
         for(var i = 0, il = valueNames.length; i < il; i++) {
-            values[valueNames[i]] = ListJsHelpers.getByClass(valueNames[i], item.elm)[0].innerHTML;
+            var it = ListJsHelpers.getByClass(valueNames[i], item.elm)[0];
+            values[valueNames[i]] = it.innerText || it.textContent;
         }
         return values;
     };


### PR DESCRIPTION
We're searching for text, so it made sense to use the innerText instead of innerHTML.
Also, when using the library I came across the fact that, when you have, for example, an item with ampersand somewhere in the list, you'd find it when searching for "amp", because innerHTML returns an html-encoded &amp;
