### PR TITLE
Sort btn highlight

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -67,6 +67,27 @@ var List = function(id, options, values) {
         h.addEvent(h.getByClass(options.searchClass, self.listContainer), 'keyup', self.search);
         sortButtons = h.getByClass(options.sortClass, self.listContainer);
         h.addEvent(sortButtons, 'click', self.sort);
+        // Kill highlight on sort buttons
+        var btn, computed_style;
+        for (var i = 0, il = sortButtons.length; i < il; i++) {
+            btn = sortButtons[i];
+            if ("unselectable" in btn) {
+                // IE, Opera
+                btn.unselectable = true;
+            } else if (window.getComputedStyle) {
+                computed_style = window.getComputedStyle(btn, null);
+
+                if ('MozUserSelect' in computed_style) {
+                    btn.style.MozUserSelect = "none";
+                } else if ('webkitUserSelect' in computed_style) {
+                    btn.style.webkitUserSelect = "none";
+                } else {
+                    return;
+                }
+            } else {
+                return;
+            }
+        }
         if (options.valueNames) {
             var itemsToIndex = initialItems.get(),
                 valueNames = options.valueNames;


### PR DESCRIPTION
If a sort button is not an actual button (as in the example), the text on it can be highlighted accidentally with a double click, which is a bit awkward.

This patch fixes the problem without having to add anything to the CSS, but it's a lot of lines to do the job.

The alternative is to use an actual button element for the sort, instead of a span.
