### PR TITLE
Script breaks when no listContainer is found

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -45,6 +45,10 @@ var List = function(id, options, values) {
 		    'updated': []
 		};
     this.listContainer = (typeof(id) == 'string') ? document.getElementById(id) : id;
+    // Check if the container exists. If not return instead of breaking the javascript
+    if (!this.listContainer)
+        return;
+    
     this.items = [];
     this.visibleItems = []; // These are the items currently visible
     this.matchingItems = []; // These are the items currently matching filters and search, regadlessof visible count


### PR DESCRIPTION
In case of multiple list the script break when can't find the id of the listContainer. This fix prevent the break, stopping the execution of the rest of the script.
