### PR TITLE
Ensure nodes is an object (typeo fix)

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -687,7 +687,7 @@ h = {
     /* http://stackoverflow.com/questions/7238177/detect-htmlcollection-nodelist-in-javascript */
     isNodeList: function(nodes) {
         var result = Object.prototype.toString.call(nodes);
-        if (typeof nodes === 'object' && /^\[object (HTMLCollection|NodeList|Object)\]$/.test(result) && (nodes.length == 0 || (typeof nodes === "object" && nodes[0].nodeType > 0))) {
+        if (typeof nodes === 'object' && /^\[object (HTMLCollection|NodeList|Object)\]$/.test(result) && (nodes.length == 0 || (typeof nodes[0] === "object" && nodes[0].nodeType > 0))) {
             return true;
         }
         return false;


### PR DESCRIPTION
prevents `0.nodeType is null or not an object` js error
