### PR TITLE
Search: add the ability to specify searchColumns in list options.

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -49,6 +49,7 @@ var List = function(id, options, values) {
     if (!this.listContainer)
         return;
 
+    this.options = options;
     this.items = [];
     this.visibleItems = []; // These are the items currently visible
     this.matchingItems = []; // These are the items currently matching filters and search, regadlessof visible count
@@ -299,7 +300,7 @@ var List = function(id, options, values) {
             text,
             values,
             is,
-            columns = (columns === undefined) ? self.items[0].values() : columns,
+            columns = columns || self.options.searchColumns || self.items[0].values(),
             searchString = (searchString === undefined) ? "" : searchString,
             target = searchString.target || searchString.srcElement; /* IE have srcElement */
 

--- a/tests/index.html
+++ b/tests/index.html
@@ -17,6 +17,10 @@
 	<ol id="qunit-tests"></ol>
 	<div id="qunit-fixture">test markup</div>
 
+	<div id="list2" style="visibility:hidden;">
+		<input class="search" />
+    <ul class="list"></ul>
+  </div>
 
 	<div id="list" style="visibility:hidden;">
 		<input class="search" />

--- a/tests/list.tests.js
+++ b/tests/list.tests.js
@@ -145,6 +145,25 @@ test('Search with undefined values', function() {
     }
 });
 
+test('Search with searchColumns', function() {
+  var list2options = {
+    item: '<li><div class="title"></div><div class="body"></div></li>',
+    searchColumns: {title: true}
+  };
+  var list2data = [
+    {title: 'title one', body: 'body always has one'},
+    {title: 'title two', body: 'body always has one'},
+    {title: 'title three', body: 'body always has one'}
+  ];
+  var list2 = new List('list2', list2options, list2data);
+  var items = list2.search('title');
+  equal(items.length, 3);
+  var items = list2.search('one');
+  equal(items.length, 1);
+  var items = list2.search('always');
+  equal(items.length, 0);
+});
+
 test('Filter', function() {
     var visibleItems = theList.filter(function(item) {
         if (+item.values().id < 3) {


### PR DESCRIPTION
If columns is not defined, the search function currently uses all of the keys from the first item.
In my use case, I wanted to be able to specify which columns are searchable in the options when creating a list.

Now the options you can specify search columns like this:

```
options = {
  searchColumns: {title: true}
}
```
