### PR TITLE
Allow an array of columns names parameter to search.

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -303,6 +303,14 @@ var List = function(id, options, values) {
             searchString = (searchString === undefined) ? "" : searchString,
             target = searchString.target || searchString.srcElement; /* IE have srcElement */
 
+        if (h.isArray(columns)) {  // convert array to object
+            var arr_columns = columns;
+            columns = {}
+            for (var c = 0, cl = arr_columns.length; c < cl; c++) {
+                columns[arr_columns[c]] = 1;
+            }
+        }
+
         searchString = (target === undefined) ? (""+searchString).toLowerCase() : ""+target.value.toLowerCase();
         is = self.items;
         // Escape regular expression characters
@@ -691,6 +699,10 @@ h = {
             return true;
         }
         return false;
+    },
+    isArray: function(obj) {
+        var result = Object.prototype.toString.call(obj);
+        return result === "[object Array]";
     },
     hasClass: function(ele, classN) {
         var classes = this.getAttribute(ele, 'class') || this.getAttribute(ele, 'className') || "";

--- a/tests/list.tests.js
+++ b/tests/list.tests.js
@@ -80,6 +80,32 @@ test('Search', function() {
     theList.search(); 
 });
 
+test('Search with array columns', function() {
+    var items = theList.search('Ryan', ['name']);
+    equals(items.length, 1);
+    items = [
+        items[0].values()
+    ];
+    deepEqual(items, [ryah]);
+    theList.search();
+});
+
+test('Search with object columns', function() {
+    var items = theList.search('TJ', {'name': 1});
+    equals(items.length, 1);
+    items = [
+        items[0].values()
+    ];
+    deepEqual(items, [tj]);
+    theList.search();
+});
+
+test('Search with columns wrong column', function() {
+    var items = theList.search('Node', {'name': 1});
+    equals(items.length, 0);
+    theList.search();
+});
+
 test('Search with null values', function() {
     var objectWithNulls = {
         id: 7


### PR DESCRIPTION
Rather than only allowing a columns object parameter e.g.

```
alist.search("search string", {name: 1, feature: 1});
```

also allow a columns array parameter:

```
alist.search("search string", ['name', 'feature']);
```
