### PR TITLE
Optional support for search matching on word boundaries and full words using regex

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -1,12 +1,12 @@
 /*
 ListJS Beta 0.2.0
-By Jonny Strömberg (www.jonnystromberg.com, www.listjs.com)
+By Jonny StrÃ¶mberg (www.jonnystromberg.com, www.listjs.com)
 
 OBS. The API is not frozen. It MAY change!
 
 License (MIT)
 
-Copyright (c) 2011 Jonny Strömberg http://jonnystromberg.com
+Copyright (c) 2011 Jonny StrÃ¶mberg http://jonnystromberg.com
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation
@@ -60,6 +60,7 @@ var List = function(id, options, values) {
 
     this.page = options.page || 200;
     this.i = options.i || 1;
+    this.searchType = options.searchType || 'any';
 
     init = {
         start: function(values, options) {
@@ -315,6 +316,14 @@ var List = function(id, options, values) {
             self.update();
         } else {
             self.searched = true;
+            console.log(self);
+            if(self.searchType == 'any'){
+            	var regpattern = new RegExp(searchString);
+            } else if(self.searchType == 'word'){
+            	var regpattern = new RegExp('\\b' + searchString);
+            } else if(self.searchType == 'wordFull') {
+				var regpattern = new RegExp('\\b' + searchString + '\\b');
+            }
 
             for (var k = 0, kl = is.length; k < kl; k++) {
                 found = false;
@@ -324,7 +333,7 @@ var List = function(id, options, values) {
                 for(var j in columns) {
                     if(values.hasOwnProperty(j) && columns[j] !== null) {
                         text = (values[j] != null) ? values[j].toString().toLowerCase() : "";
-                        if ((searchString !== "") && (text.search(searchString) > -1)) {
+                        if ((searchString !== "") && (regpattern.test(text))) {
                             found = true;
                         }
                     }

--- a/src/list.js
+++ b/src/list.js
@@ -316,7 +316,6 @@ var List = function(id, options, values) {
             self.update();
         } else {
             self.searched = true;
-            console.log(self);
             if(self.searchType == 'any'){
             	var regpattern = new RegExp(searchString);
             } else if(self.searchType == 'word'){

--- a/src/list.js
+++ b/src/list.js
@@ -322,7 +322,7 @@ var List = function(id, options, values) {
             } else if(self.searchType == 'word'){
             	var regpattern = new RegExp('\\b' + searchString);
             } else if(self.searchType == 'wordFull') {
-				var regpattern = new RegExp('\\b' + searchString + '\\b');
+            	var regpattern = new RegExp('\\b' + searchString + '\\b');
             }
 
             for (var k = 0, kl = is.length; k < kl; k++) {

--- a/src/list.js
+++ b/src/list.js
@@ -1,12 +1,12 @@
 /*
 ListJS Beta 0.2.0
-By Jonny StrÃ¶mberg (www.jonnystromberg.com, www.listjs.com)
+By Jonny Strömberg (www.jonnystromberg.com, www.listjs.com)
 
 OBS. The API is not frozen. It MAY change!
 
 License (MIT)
 
-Copyright (c) 2011 Jonny StrÃ¶mberg http://jonnystromberg.com
+Copyright (c) 2011 Jonny Strömberg http://jonnystromberg.com
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation


### PR DESCRIPTION
Added support for different types of search matching using regex. The performance appears to be quite similar with new versions of Chrome and Firefox actually being faster using .test() instead of .search() (See http://jsperf.com/exec-vs-match-vs-test/5).

Options are set using the "searchType" in the options field. The three options are

any: default option which matches on any position in the string. Example: no will match "equinox"
word: matches only from the start of regex word boundaries (\b). Example: no will match "nokia" and "pizza no" but not "equinox". 
wordFull: matches only exact words with regex word boundaries on both ends. Example: no will match only "pizza no" and not "nokia" or "equinox"
