### PR TITLE
Added emptyView plugin

### DIFF
--- a/plugins/emptyView/list.emptyView.js
+++ b/plugins/emptyView/list.emptyView.js
@@ -1,0 +1,21 @@
+List.prototype.plugins.emptyView = function(locals, options) {
+  var list = this;
+  var emptyView = document.getElementById(options.emptyViewId);
+  if(emptyView){
+    var visibleDisplayType = options.visibleDisplayType || "block";
+    var hiddenDisplayType = "none";
+    list.on('updated', function(){
+      if(list.visibleItems < 1)
+      {
+        emptyView.style.display = visibleDisplayType;
+      }
+      else
+      {
+        emptyView.style.display = hiddenDisplayType;
+      }
+    });
+    list.update();
+  }else{
+    console.log("Could not find the emptyView")
+  }
+};

--- a/plugins/emptyView/list.emptyView.min.js
+++ b/plugins/emptyView/list.emptyView.min.js
@@ -1,0 +1,1 @@
+List.prototype.plugins.emptyView=function(e,t){var n=this;var r=document.getElementById(t.emptyViewId);if(r){var i=t.visibleDisplayType||"block";var s="none";n.on("updated",function(){if(n.visibleItems<1){r.style.display=i}else{r.style.display=s}});n.update()}else{console.log("Could not find the emptyView")}}


### PR DESCRIPTION
Added a plugin to mark a view as an "empty view". This view will be hidden unless the list is empty, a good use for this is to mark a "No search results found" view as an empty view
