### PR TITLE
Undefined/Null/Empty string should use one space

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -716,11 +716,11 @@ h = {
     */
     sorter: {
         alphanum: function(a,b,asc) {
-            if (a === undefined || a === null) {
-                a = "";
+            if (!a) {
+                a = " ";
             }
-            if (b === undefined || b === null) {
-                b = "";
+            if (!b) {
+                b = " ";
             }
             a = a.toString().replace(/&(lt|gt);/g, function (strMatch, p1){
                 return (p1 == "lt")? "<" : ">";


### PR DESCRIPTION
If you have a list with missing data in it, as it might be optional, the data no longer appropriately sorts as expected. The items without data stick to the top no matter the sorting, this resolves that.
