### PR TITLE
Add re-sorting functionality based on last sort vars

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -251,7 +251,6 @@ var List = function(id, options, values) {
             isAsc = false,
             asc = 'asc',
             desc = 'desc',
-            datatype,
             options = options || {};
 
         if (target === undefined) {
@@ -260,7 +259,6 @@ var List = function(id, options, values) {
         } else {
             value = h.getAttribute(target, 'data-sort');
             isAsc = h.hasClass(target, asc) ? false : true;
-            datatype = h.getAttribute(target, 'data-type');
         }
         for (var i = 0, il = sortButtons.length; i < il; i++) {
             h.removeClass(sortButtons[i], asc);
@@ -282,10 +280,7 @@ var List = function(id, options, values) {
             options.sortFunction = options.sortFunction;
         } else {
             options.sortFunction = function(a, b) {
-                if (datatype=='number')
-                    return h.sorter.number(a.values()[value], b.values()[value], isAsc);
-                else
-                    return h.sorter.alphanum(a.values()[value].toLowerCase(), b.values()[value].toLowerCase(), isAsc);
+                return h.sorter.alphanum(a.values()[value].toLowerCase(), b.values()[value].toLowerCase(), isAsc);
             };
         }
         self.items.sort(options.sortFunction);


### PR DESCRIPTION
After dynamically editing items in a sorted list, I noticed that the list did not update to reflect the previously selected sorting. This small hack fixed it for me and a similar if not identical functionality should be implemented in the master branch.

This is very useful when sorting dynamic lists with numerical values and always want lowest/highest values on top.
