### PR TITLE
Columns to be searched configured by data-attribute of search input 

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -303,7 +303,7 @@ var List = function(id, options, values) {
             target = searchString.target || searchString.srcElement; /* IE have srcElement */
 
         searchString = (target === undefined) ? (""+searchString).toLowerCase() : ""+target.value.toLowerCase();
-	// either use the function's argument, the data-attribute on the search input or all fields of an item 
+        // either use the function's argument, the data-attribute on the search input or all fields of an item 
         var columns = searchColumns; 
         if (columns === undefined) {
             if (target) {
@@ -317,7 +317,7 @@ var List = function(id, options, values) {
             columns = self.items[0].values();
         }        
 
-	is = self.items;
+        is = self.items;
         // Escape regular expression characters
         searchString = searchString.replace(/[-[\]{}()*+?.,\\^$|#\s]/g, "\\$&");
 


### PR DESCRIPTION
Previously, it seems, only all columns could be searched, even if there were preparations made to specify certain columns to be searched (and exclude the others). With these changes, a data-searchColumn attribute can be defined on every search input. In this data-attribute a json-object specifies the columns to be searched, like this:<code>&lt;input type='text' class='search' data-searchColumn='{'name':true}' /&gt;</code>
