### PR TITLE
Support Bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,11 @@
+{
+  "name": "list.js",
+  "version": "0.2.1",
+  "ignore": [
+    "**/.*",
+    "plugins",
+    "src",
+    "tests",
+    "website"
+  ]
+}


### PR DESCRIPTION
This adds bower.json to support Bower, but also means you should tag each release with `v0.2.1` so Bower knows what versions are available.
