### PR TITLE
Fix typo in method name

### DIFF
--- a/README.md
+++ b/README.md
@@ -414,7 +414,7 @@ Hides the item (removes the element from the list, and then when its shown it's 
 Returns boolean. True if the item matches the current filter and search. Visible items 
 always matches, but matching items are not always visible.
 
-* **visisble()**  
+* **visible()**  
 Returns boolean. True if the item is visible. Visible items 
 always matches, but matching items are not always visible.
 


### PR DESCRIPTION
In the README file, the `visible` method name was misspelled.
