### PR TITLE
paging: Add support for setting listitem-HTML in the options

### DIFF
--- a/plugins/paging/list.paging.js
+++ b/plugins/paging/list.paging.js
@@ -5,7 +5,7 @@ List.prototype.plugins.paging = function(locals, options) {
         options = options || {};
         pagingList = new List(list.listContainer.id, {
             listClass: options.pagingClass || 'paging',
-            item: "<li><div class='page'></div></li>", // Have to contain something, can't set valueName at root element
+            item: options.itemHtml || "<li><div class='page'></div></li>", // Have to contain something, can't set valueName at root element
             valueNames: ['page', 'dotted'],
             searchClass: 'nosearchclass',
             sortClass: 'nosortclass'


### PR DESCRIPTION
Usage (works with bootstrap pagination):

```
var filterPagingOptions = {
    outerWindow: 1,
    innerWindow: 1,
    itemHtml: '<li><span class="page"></span></li>'
};
var filterOptions = {
    valueNames: ['name', 'date'],
    page: 50,
    plugins: [
        [ 'paging', filterPagingOptions ],
    ]
};
```
