### PR TITLE
Update template engine to support <img/> elements

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -557,7 +557,11 @@ List.prototype.templateEngines.standard = function(list, settings) {
                 // TODO speed up if possible
                 var elm = h.getByClass(v, item.elm, true);
                 if (elm) {
-                    elm.innerHTML = values[v];
+                    if (elm.tagName === "IMG" && values[v] !== "") {
+                        elm.src = values[v];
+                    } else {
+                        elm.innerHTML = values[v];
+                    }
                 }
             }
         }


### PR DESCRIPTION
When add list items based on such template:

``` html
<ul id="properties-list" class="list">
  <li class="property_item">
    <img class="property_image" src="1.jpg" alt=""/>
    <h2 class="property_name">Hotel 1</h2>
    <span class="property_price">100$</span>
    <span class="property_location">Adventure Bay</span>
    <p class="property_description">Lorem ipsum...</p>
  </li>
</ul>
```

``` js
propertiesList.add({
  property_image: "2.jpg",
  property_name: "Hotel 2",
  property_price: "200$",
  property_location: "Hell",
  property_description: "Yeah"
});
```

"property_image" value should became not elm.innerHTML but elm.src
