### PR TITLE
fix sorting on numeric columns

### DIFF
--- a/src/list.js
+++ b/src/list.js
@@ -719,21 +719,24 @@ h = {
     */
     sorter: {
         alphanum: function(a,b,asc) {
-            if (!a) {
+            if (!a && a !== 0) {
                 a = " ";
             }
-            if (!b) {
+            if (!b && b !== 0) {
                 b = " ";
             }
             a = a.toString().replace(/&(lt|gt);/g, function (strMatch, p1){
                 return (p1 == "lt")? "<" : ">";
             });
             a = a.replace(/<\/?[^>]+(>|$)/g, "");
-
             b = b.toString().replace(/&(lt|gt);/g, function (strMatch, p1){
                 return (p1 == "lt")? "<" : ">";
             });
             b = b.replace(/<\/?[^>]+(>|$)/g, "");
+
+            if (a == " " && b == " ") return 0;
+            if (a == " ") return asc ? -1 : 1;
+            if (b == " ") return asc ? 1 : -1;
             var aa = this.chunkify(a);
             var bb = this.chunkify(b);
 


### PR DESCRIPTION
Addressing two issues with sorting columns containing numeric values: 
1. javascript error when trying to sort -- TypeError: Object 3.45 has no method 'toLowerCase'
2. separate out blanks from 0's

Edit: it looks like there's a separate pull request for the first issue (https://github.com/javve/list.js/pull/160).  I'll leave the commit list unchanged, just in case there are any incompatibilities.
