### PR TITLE
Update templater to support <img/> elements

### DIFF
--- a/src/templater.js
+++ b/src/templater.js
@@ -44,7 +44,12 @@ var Templater = function(list) {
                     // TODO speed up if possible
                     var elm = getByClass(item.elm, v, true);
                     if (elm) {
-                        elm.innerHTML = values[v];
+                        /* src attribute for image tag & text for other tags */
+                        if (elm.tagName === "IMG" && values[v] !== "") {
+                            elm.src = values[v];
+                        } else {
+                            elm.innerHTML = values[v];
+                        }
                     }
                 }
             }


### PR DESCRIPTION
When add list items based on such template:

``` html
<ul id="properties-list" class="list">
  <li class="property_item">
    <img class="property_image" src="1.jpg" alt=""/>
    <h2 class="property_name">Hotel 1</h2>
    <span class="property_price">100$</span>
    <span class="property_location">Adventure Bay</span>
    <p class="property_description">Lorem ipsum...</p>
  </li>
</ul>
```

``` js
propertiesList.add({
  property_image: "2.jpg",
  property_name: "Hotel 2",
  property_price: "200$",
  property_location: "Hell",
  property_description: "Yeah"
});
```

"property_image" value should became not elm.innerHTML but elm.src
