### PR TITLE
Warn when id not found

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ var List = function(id, options, values) {
             extend(self, options);
 
             self.listContainer = (typeof(id) === 'string') ? document.getElementById(id) : id;
-            if (!self.listContainer) { return; }
+            if (!self.listContainer) { console.warn("Required container not found"); return; }
             self.list           = getByClass(self.listContainer, self.listClass, true);
 
             self.templater      = require('./src/templater')(self);


### PR DESCRIPTION
If init fails a warning should be issued. The element/id is required but if it is not found list.js should issue a warning and not just fail silently. This will help debug why the script doesn't seem to work
