### PR TITLE
exclude HTML tag content from search

### DIFF
--- a/dist/list.js
+++ b/dist/list.js
@@ -996,7 +996,13 @@ module.exports = function(list) {
         },
         values: function(values, column) {
             if (values.hasOwnProperty(column)) {
-                text = toString(values[column]).toLowerCase();
+                if(/^<[^>]+>/.test(values[column])){
+                    remplace = $(values[column]).clone();
+                    remplace.not(":visible").remove();
+                    text = toString(remplace.html()).toLowerCase();
+                } else {
+                    text = toString(values[column]).toLowerCase();
+                }
                 if ((searchString !== "") && (text.search(searchString) > -1)) {
                     return true;
                 }

--- a/src/search.js
+++ b/src/search.js
@@ -58,7 +58,13 @@ module.exports = function(list) {
         },
         values: function(values, column) {
             if (values.hasOwnProperty(column)) {
-                text = toString(values[column]).toLowerCase();
+                if(/^<[^>]+>/.test(values[column])){
+                    remplace = $(values[column]).clone();
+                    remplace.not(":visible").remove();
+                    text = toString(remplace.html()).toLowerCase();
+                } else {
+                    text = toString(values[column]).toLowerCase();
+                }
                 if ((searchString !== "") && (text.search(searchString) > -1)) {
                     return true;
                 }


### PR DESCRIPTION
When tables contains hidden HTML tags, search will select them for filter.
This commit fix that. 