### PR TITLE
item template given capability to render links into item markup

### DIFF
--- a/dist/list.js
+++ b/dist/list.js
@@ -1264,11 +1264,14 @@ var Templater = function(list) {
                 if (values.hasOwnProperty(v)) {
                     // TODO speed up if possible
                     var elm = getByClass(item.elm, v, true);
-                    if (elm) {
+                    if (elm && values[v] !== "") {
                         /* src attribute for image tag & text for other tags */
-                        if (elm.tagName === "IMG" && values[v] !== "") {
+                        if (elm.tagName === "IMG") {
                             elm.src = values[v];
-                        } else {
+                        } else if(elm.tagName === "A"){
+                            elm.setAttribute("href", values[v]);
+                        }
+                        else {
                             elm.innerHTML = values[v];
                         }
                     }

--- a/src/templater.js
+++ b/src/templater.js
@@ -43,11 +43,13 @@ var Templater = function(list) {
         if (values.hasOwnProperty(v)) {
           // TODO speed up if possible
           var elm = getByClass(item.elm, v, true);
-          if (elm) {
+          if (elm && values[v] !== "") {
             /* src attribute for image tag & text for other tags */
-            if (elm.tagName === "IMG" && values[v] !== "") {
+            if (elm.tagName === "IMG" ) {
               elm.src = values[v];
-            } else {
+            } else if(elm.tagName === "A"){
+              elm.setAttribute("href", values[v]);
+            }else {
               elm.innerHTML = values[v];
             }
           }


### PR DESCRIPTION
I was using list.js help make a searchable tile based ui for blog articles but had to write a hack to get the links inserted into the markup correctly as templates currently lack the ability to render into the href attribute of link elements. Rendering links seems like a useful thing for the templates to be able to do and my proposed solution is very simple.
