### PR TITLE
Add "default-order" option to sort buttons

### DIFF
--- a/src/sort.js
+++ b/src/sort.js
@@ -27,7 +27,12 @@ module.exports = function(list) {
       } else if (classes(btn).has('asc')) {
         return "desc";
       } else {
-        return "asc";
+        var defaultOrder = getAttribute(btn, 'data-default-order');
+        if (defaultOrder == "asc" || defaultOrder == "desc") {
+          return defaultOrder;
+        } else {
+          return "asc";
+        }
       }
     },
     getInSensitive: function(btn, options) {


### PR DESCRIPTION
This allows column-by-column overrides of the previously hard-coded "asc" default sort order.