### PR TITLE
Support for <tr... in options.item

### DIFF
--- a/src/templater.js
+++ b/src/templater.js
@@ -16,6 +16,10 @@ var Templater = function(list) {
         }
       }
       return null;
+    } else if (/^tr[\s>]/.exec(item)) { 
+      var table = document.createElement('table');
+      table.innerHTML = item;
+      return table.firstChild;
     } else if (item.indexOf("<") !== -1) { // Try create html element of list, do not work for tables!!
       var div = document.createElement('div');
       div.innerHTML = item;


### PR DESCRIPTION
This adds support for using using tr in options.item when creating a list, like `item:"<tr>....</tr>"`

But I just realised that you can use...  `new List(...,{item:"idOfTr"});`

And have `<tr id='idOfTr'></tr>` in the html.

Wasn't obvious to me at the time.