### PR TITLE
add in default search columns option

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ Features/problems I'll implement/fix in the future. (issues about 'em will be cl
 * [jkeyes](https://github.com/jkeyes) / [John Keyes](http://keyes.ie/)
 * [samosad](https://github.com/samosad) / Alexey Tabakman
 * [Page-](https://github.com/Page-)
+* [urkle](https://github.com/urkle) / Edward Rudd
 
 Built with [Component](https://github.com/component/component) which is created by [TJ Holowaychuk](https://github.com/visionmedia).
 

--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ var List = function(id, options, values) {
       self.matchingItems  = [];
       self.searched       = false;
       self.filtered       = false;
+      self.searchColumns  = undefined;
       self.handlers       = { 'updated': [] };
       self.plugins        = {};
       self.helpers        = {

--- a/src/search.js
+++ b/src/search.js
@@ -26,7 +26,9 @@ module.exports = function(list) {
       }
     },
     setColumns: function() {
-      columns = (columns === undefined) ? list.valueNames : columns;
+      if (columns === undefined) {
+        columns = (list.searchColumns === undefined) ? prepare.toArray(list.items[0].values()) : list.searchColumns;
+      }
     },
     setSearchString: function(s) {
       s = toString(s).toLowerCase();

--- a/test/test.search.js
+++ b/test/test.search.js
@@ -69,6 +69,22 @@ describe('Search', function() {
     });
   });
 
+
+  describe('Default search columns', function() {
+    it('should find in the default match column', function() {
+      list.searchColumns = ['name'];
+      var result = list.search('jonny');
+      expect(result.length).to.equal(1);
+      expect(result[0]).to.eql(jonny);
+    });
+    it('should not find in the default match column', function() {
+      list.searchColumns = ['born'];
+      var result = list.search('jonny');
+      expect(result.length).to.equal(0);
+    });
+  });
+
+
   describe('Specfic columns', function() {
     it('should find match in column', function() {
       var result = list.search('jonny', [ 'name' ]);


### PR DESCRIPTION
this adds a new option named "searchColumns" that allows you to specify a default set of columns to use when searching of fuzzy searching. 