### PR TITLE
Sort by what is seen on the page

### DIFF
--- a/src/templater.js
+++ b/src/templater.js
@@ -31,7 +31,7 @@ var Templater = function(list) {
     var values = {};
     for(var i = 0, il = valueNames.length; i < il; i++) {
       var elm = getByClass(item.elm, valueNames[i], true);
-      values[valueNames[i]] = elm ? elm.innerHTML : "";
+      values[valueNames[i]] = elm ? elm.textContent : "";
     }
     return values;
   };


### PR DESCRIPTION
If innerHTML is used, as is now, eg. table-rows with a link in the sorting column's table-data are sorted by the target href or whatever attribute is there in the source instead of the link text