### PR TITLE
fix <tr> regex selector & return row

### DIFF
--- a/src/templater.js
+++ b/src/templater.js
@@ -41,10 +41,10 @@ var Templater = function(list) {
           return nodes[i].cloneNode(true);
         }
       }
-    } else if (/^tr[\s>]/.exec(item)) {
-      var table = document.createElement('table');
-      table.innerHTML = item;
-      return table.firstChild;
+    } else if (/<tr[\s>]/g.exec(item)) {
+      var tbody = document.createElement('tbody');
+      tbody.innerHTML = item;
+      return tbody.firstChild;
     } else if (item.indexOf("<") !== -1) {
       var div = document.createElement('div');
       div.innerHTML = item;


### PR DESCRIPTION
Resolves #403 

Previously, item templates involving `<tr>` elements were being handled in the `else` clause, which resulted in negating the `tr` wrapper since `div > tr` is invalid DOM:

```html
<div>
  <h3 class="name"></h3><p class="born"></p>
</div>
```

Returning `div.firstChild` returned the contents only, producing invalid `<tbody>` rows