### PR TITLE
Adds minLength parameter to options

### DIFF
--- a/src/search.js
+++ b/src/search.js
@@ -83,7 +83,11 @@ module.exports = function(list) {
     } else {
       list.searched = true;
       if (customSearch) {
-        customSearch(searchString, columns);
+        if(list.minLength === undefined){
+          customSearch(searchString, columns);
+        }else if(searchString.length >= list.minLength){
+          customSearch(searchString, columns);
+        }
       } else {
         search.list();
       }


### PR DESCRIPTION
If minLength is defined, the customSearch() is triggered only when the length of the searchString equals or exceeds the minLength value
