### PR TITLE
Retrieve item element via firstElementChild instead of firstChild

### DIFF
--- a/src/templater.js
+++ b/src/templater.js
@@ -44,11 +44,11 @@ var Templater = function(list) {
     } else if (/^tr[\s>]/.exec(item)) {
       var table = document.createElement('table');
       table.innerHTML = item;
-      return table.firstChild;
+      return table.firstElementChild;
     } else if (item.indexOf("<") !== -1) {
       var div = document.createElement('div');
       div.innerHTML = item;
-      return div.firstChild;
+      return div.firstElementChild;
     } else {
       var source = document.getElementById(list.item);
       if (source) {


### PR DESCRIPTION
`firstChild` may return a text node which causes `getElementsByClassName` in get-by-class.js file to fail because text nodes don't respond to that.