### PR TITLE
Fixed documentation on fuzzyOptions

### DIFF
--- a/docs/docs/plugins/fuzzysearch.html
+++ b/docs/docs/plugins/fuzzysearch.html
@@ -55,7 +55,7 @@ var fuzzyOptions = {
 var options = {
   valueNames: [ 'name', 'category' ],
   plugins: [
-    ListFuzzySearch()
+    ListFuzzySearch(fuzzyOptions)
   ]
 };
 


### PR DESCRIPTION
The fuzzyOptions variable was not passed to the plugin.

This is related to #304 