### PR TITLE
Updated cdnjs link and fixed html

### DIFF
--- a/docs/docs/plugins/pagination.html
+++ b/docs/docs/plugins/pagination.html
@@ -18,7 +18,7 @@ title: Pagination plugin
 
     <% /*
     <h4>Via <a href="http://cdnjs.com/">CDNJS</a></h4>
-    <pre><code>&lt;link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/List.pagination.js/1.0.0/list.pagination.min.js" /></code></pre>
+    <pre><code><script src="//cdnjs.cloudflare.com/ajax/libs/list.pagination.js/0.1.1/list.pagination.min.js"></script></code></pre>
     */ %>
 
 <h3>Basic example</h3>


### PR DESCRIPTION
The previous URL is not accessible. I supposed the tag should be "script" instead of "link".