### PR TITLE
Avoid CSP violation when using pagination due to inline javascript

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -82,7 +82,7 @@ module.exports = function(list) {
   return function(options) {
     var pagingList = new List(list.listContainer.id, {
       listClass: options.paginationClass || 'pagination',
-      item: "<li><a class='page' href='javascript:function Z(){Z=\"\"}Z()'></a></li>",
+      item: "<li><a class='page' href='#'></a></li>",
       valueNames: ['page', 'dotted'],
       searchClass: 'pagination-search-that-is-not-supposed-to-exist',
       sortClass: 'pagination-sort-that-is-not-supposed-to-exist'

--- a/src/pagination.js
+++ b/src/pagination.js
@@ -92,7 +92,9 @@ module.exports = function(list) {
       var target = e.target || e.srcElement
         , page = list.utils.getAttribute(target, 'data-page')
         , i = list.utils.getAttribute(target, 'data-i');
-      list.show((i-1)*page + 1, page);
+      if(i){      
+        list.show((i-1)*page + 1, page);
+      }
     });
 
     list.on('updated', function() {


### PR DESCRIPTION
Minor change to avoid CSP violation when using pagination due to inline javascript.
As discussed in issue #498.