### PR TITLE
Remove duplicate list property in api properties documentation

### DIFF
--- a/docs/api.html
+++ b/docs/api.html
@@ -193,13 +193,6 @@ Values to add to the list on initialization.</p></li>
       Returns true if there is an active filter.
     </p>
   </li>
-  <li>
-    <p>
-      <strong>list <a name="list" class="anchor" href="#list"></a></strong>
-      <em class="docs-parameter-description">Element</em><br>
-      The element containing all items.
-    </p>
-  </li>
 </ul>
 
 <h3><a name="methods" class="anchor" href="#methods"></a>Methods</h3>


### PR DESCRIPTION
Noticed the following snippet was duplicated in the properties section of the docs. Went ahead and removed it.

```html
  <li>
    <p>
      <strong>list <a name="list" class="anchor" href="#list"></a></strong>
      <em class="docs-parameter-description">Element</em><br>
      The element containing all items.
    </p>
  </li>
```