### PR TITLE
Makes the pagination work correctly with fuzzy search

### DIFF
--- a/src/fuzzy-search.js
+++ b/src/fuzzy-search.js
@@ -56,7 +56,7 @@ module.exports = function(list, options) {
   };
 
 
-  events.bind(getByClass(list.listContainer, options.searchClass), 'keyup', function(e) {
+  list.utils.events.bind(list.utils.getByClass(list.listContainer, list.searchClass), 'keyup', function(e) {
     var target = e.target || e.srcElement; // IE have srcElement
     list.search(target.value, fuzzySearch.search);
   });


### PR DESCRIPTION
At the moment, when using pagination with fuzzy search, the pagination disappears after page 2. This prevents that from happening.