### PR TITLE
Value getters

### DIFF
--- a/src/templater.js
+++ b/src/templater.js
@@ -72,6 +72,9 @@ var Templater = function(list) {
       } else if (valueNames[i].attr && valueNames[i].name) {
         elm = list.utils.getByClass(item.elm, valueNames[i].name, true);
         values[valueNames[i].name] = elm ? list.utils.getAttribute(elm, valueNames[i].attr) : "";
+      } else if (valueNames[i].getter && valueNames[i].name) {
+        elm = list.utils.getByClass(item.elm, valueNames[i].name, true);
+        values[valueNames[i].name] = valueNames[i].getter(elm, i);
       } else {
         elm = list.utils.getByClass(item.elm, valueNames[i], true);
         values[valueNames[i]] = elm ? elm.innerHTML : "";


### PR DESCRIPTION

**Background**: I have a usecase where it's really handy for me to be able to filter and sort on if a checkbox is checked. For some reason the `~/utils/getAttribute.js` implementation does not work on the `checked` attribute. `elm.checked` does work however, as does `elm.hasAttribute("checked")`. I figured all kinds of weird and wacky use-cases have probably come up over the years that you've had this project. So I want to propose a way that I can hook my own value getter for a list element.

This still get's the list item by class, e.g. for me I have list items which look like this:

```html
<li class="group">
  <input type="checkbox" value="checked" class="toggle-state" />
  <h3 class="name">...</h3>
</li>
```

This PR allows me to do the following:

```javascript
var options = {
  valueNames:[
    "name",
    {name: "toggle-state", getter: function(elm, index){ elm ? elm.checked : false }}
}
var list = new List('project-list', options);
```

the `getter` function takes the following as its arguments:
1) the element with that class, which may be `undefined` (so you can return a default) or you can do something with that element. 
2) the index in the list (if that's important for some reason)

