### PR TITLE
Update `webpack` configuration

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,18 @@
+{
+  "presets": [
+    [
+      "@babel/preset-env",
+      {
+        "useBuiltIns": false,
+        "forceAllTransforms": true,
+        "targets": {
+          "node": "6.9.0",
+        },
+        "exclude": [
+          "transform-async-to-generator",
+          "transform-regenerator"
+        ]
+      }
+    ]
+  ]
+}

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/node_modules
+/dist

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+  root: true,
+  plugins: ['prettier'],
+  extends: ['@webpack-contrib/eslint-config-webpack'],
+  rules: {
+    'prettier/prettier': [
+      'error',
+      { singleQuote: true, trailingComma: 'es5', arrowParens: 'always' },
+    ],
+  },
+  env: {
+    'browser': true,
+  },
+};

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "singleQuote": true,
+  "trailingComma": "es5",
+  "arrowParens": "always"
+}

--- a/package.json
+++ b/package.json
@@ -25,19 +25,47 @@
   "dependencies": {
     "string-natural-compare": "^2.0.2"
   },
+  "peerDependencies": {
+    "webpack": "^4.20.2"
+  },
   "devDependencies": {
-    "jest": "^23.3",
+    "@babel/core": "^7.1.2",
+    "@babel/preset-env": "^7.1.0",
+    "@webpack-contrib/eslint-config-webpack": "^3.0.0",
+    "babel-core": "^7.0.0-bridge.0",
+    "babel-loader": "^7.1.5",
+    "eslint": "^5.6.1",
+    "eslint-plugin-import": "^2.14.0",
+    "eslint-plugin-prettier": "^3.0.0",
+    "husky": "^1.1.1",
+    "jest": "^23.6",
     "jquery": "^3.3.1",
-    "jshint": "^2.9.4",
-    "jshint-loader": "^0.8.4",
-    "webpack": "^3.12.0"
+    "lint-staged": "^7.3.0",
+    "prettier": "^1.14.3",
+    "uglifyjs-webpack-plugin": "^2.0.1",
+    "webpack": "^4.20.2",
+    "webpack-cli": "^3.1.2"
   },
   "main": "src/index",
   "engines": {
     "node": ">= 0.10.21"
   },
+  "browserslist": "> 0.25%, not dead",
+  "pre-commit": "lint-staged",
+  "lint-staged": {
+    "*.js": [
+      "eslint --fix",
+      "git add"
+    ]
+  },
   "scripts": {
-    "test": "jest"
+    "bundle": "webpack -p --config webpack.config.js",
+    "test": "jest",
+    "lint": "eslint --fix src",
+    "precommit": "lint-staged",
+    "prepush": "npm test",
+    "postmerge": "npm install && npm prune",
+    "postrewrite": "npm install && npm prune"
   },
   "npmName": "list.js",
   "npmFileMap": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,34 +1,50 @@
-const webpack = require('webpack'),
-      PACKAGE = require('./package.json');
+const webpack = require('webpack');
+const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+
+const PACKAGE = require('./package.json');
 
 module.exports = {
   entry: {
     list: './src/index.js',
-    "list.min": './src/index.js'
+    'list.min': './src/index.js',
   },
   output: {
-    path: __dirname + '/dist',
-    filename: "[name].js",
-    library: 'List'
+    path: `${__dirname}/dist`,
+    filename: '[name].js',
+    library: 'List',
   },
   module: {
-    rules: [{
-      enforce: 'pre',
-      test: /\.js$/,
-      exclude: /(node_modules|src\/utils\/extend\.js)/,
-      loader: "jshint-loader"
-    }]
+    rules: [
+      {
+        test: /\.js$/,
+        enforce: 'pre',
+        exclude: /node_modules/,
+        use: [
+          {
+            loader: 'babel-loader',
+          },
+        ],
+      },
+    ],
   },
   devServer: {
-    inline: true
+    inline: true,
+    compress: true,
+  },
+  devtool: 'cheap-module-source-map',
+  optimization: {
+    minimizer: [
+      new UglifyJsPlugin({
+        include: /\.min\.js$/,
+        sourceMap: true,
+      }),
+    ],
   },
   plugins: [
-    new webpack.optimize.UglifyJsPlugin({
-      include: /\.min\.js$/,
-      minimize: true
-    }),
     new webpack.BannerPlugin({
-      banner: 'List.js v' + PACKAGE.version + ' (' + PACKAGE.homepage + ') by ' + PACKAGE.author.name + ' (' + PACKAGE.author.url + ')'
-    })
-  ]
+      banner: `List.js v${PACKAGE.version} (${PACKAGE.homepage}) by ${
+        PACKAGE.author.name
+      } (${PACKAGE.author.url})`,
+    }),
+  ],
 };


### PR DESCRIPTION
Upgrade to latest webpack and include commit hooks. Included:
- linting with `eslint`
- code formatting with `prettier`
- transpiling via `babel`

Actually this PR would include the functionality of https://github.com/javve/list.js/pull/610 and https://github.com/javve/list.js/pull/611.