### PR TITLE
Fix broken plugins/support link on overview page

### DIFF
--- a/docs/overview/index.html
+++ b/docs/overview/index.html
@@ -24,7 +24,7 @@ title: TL;DR / Features
   <li>Sort <small><a href="{{ "/docs/list-api#sort" | relative_url }}">Read more ›</a></small></li>
   <li>Filter <small><a href="{{ "/docs/list-api#filter" | relative_url }}">Read more ›</a></small></li>
   <li>Simple templating system that adds possibility to add, edit, remove items <small><a href="{{ "/docs/list-api#add" | relative_url }}">Read more ›</a></small></li>
-  <li>Plugins <small><a href="{{ "/docs/plugins" | relative_url }}>"Read more ›</a></small></li>
+  <li>Plugins <small><a href="{{ "/docs/plugins" | relative_url }}">Read more ›</a></small></li>
   <li>Support for Chrome, Safari, Firefox, IE9+</li>
 </ul>
 


### PR DESCRIPTION
At <https://listjs.com/overview/>,
* the "Plugins" list item is plain text without link,
* the "Read more" part is not shown,
* and "Support for Chrome, " is (incorrectly) a link, to a 404 page that ends with `docs/plugins>`.

All that, due to one character swap! 🙂