### PR TITLE
Fix Node support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,64 +2,33 @@ version: 2.1
 orbs:
   node: circleci/node@4.1.0
 jobs:
-  node14:
+  test:
     executor:
       name: node/default
-      tag: '14.15.4'
+    parameters:
+      os:
+        type: string
+      node-version:
+        type: string
     steps:
       - checkout
-      - node/with-cache:
-          steps:
-            - run: npm install
-            - run: npm test
-            - run:
-                name: code-coverage
-                command: 'bash <(curl -s https://codecov.io/bash)'
-  node12:
-    executor:
-      name: node/default
-      tag: '12.20.1'
-    steps:
-      - checkout
-      - node/with-cache:
-          steps:
-            - run: npm install
-            - run: npm test
-  node10:
-    executor:
-      name: node/default
-      tag: '10.23.1'
-    steps:
-      - checkout
-      - node/with-cache:
-          steps:
-            - run: npm install
-            - run: npm test
-  node8:
-    executor:
-      name: node/default
-      tag: '8.17.0'
-    steps:
-      - checkout
-      - node/with-cache:
-          steps:
-            - run: npm install
-            - run: npm test
-  node6:
-    executor:
-      name: node/default
-      tag: '6.17.1'
-    steps:
-      - checkout
-      - node/with-cache:
-          steps:
-            - run: npm install
-            - run: npm test
+      - node/install-packages
+      - run: npm test
+      - run:
+          name: code-coverage
+          command: 'bash <(curl -s https://codecov.io/bash)'
+
 workflows:
-  build-and-test:
+  build:
     jobs:
-      - node14
-      - node12
-      - node10
-      - node8
-      - node6
+      - test:
+          matrix:
+            parameters:
+              os:
+                - docker
+              node-version:
+                - '6.17.1'
+                - '8.17.0'
+                - '10.23.1'
+                - '12.20.1'
+                - '14.15.4'

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,20 +1,65 @@
 version: 2.1
+orbs:
+  node: circleci/node@4.1.0
 jobs:
-  build:
-    docker:
-      - image: circleci/node:14.15.1
+  node14:
+    executor:
+      name: node/default
+      tag: '14.15.4'
     steps:
       - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-      - run: npm install
-      - save_cache:
-          key: dependency-cache-{{ checksum "package.json" }}
-          paths:
-            - node_modules
-      - run:
-          name: test
-          command: npm test
-      - run:
-          name: code-coverage
-          command: 'bash <(curl -s https://codecov.io/bash)'
+      - node/with-cache:
+          steps:
+            - run: npm install
+            - run: npm test
+            - run:
+                name: code-coverage
+                command: 'bash <(curl -s https://codecov.io/bash)'
+  node12:
+    executor:
+      name: node/default
+      tag: '12.20.1'
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: npm install
+            - run: npm test
+  node10:
+    executor:
+      name: node/default
+      tag: '10.23.1'
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: npm install
+            - run: npm test
+  node8:
+    executor:
+      name: node/default
+      tag: '8.17.0'
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: npm install
+            - run: npm test
+  node6:
+    executor:
+      name: node/default
+      tag: '6.17.1'
+    steps:
+      - checkout
+      - node/with-cache:
+          steps:
+            - run: npm install
+            - run: npm test
+workflows:
+  build-and-test:
+    jobs:
+      - node14
+      - node12
+      - node10
+      - node8
+      - node6

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "main": "src/index",
   "engines": {
-    "node": "^14.15.1"
+    "node": "^6.0 || ^8.0 || ^10.0 || ^12.0 || >=14"
   },
   "scripts": {
     "test": "npx jest",


### PR DESCRIPTION
I accidentally removed the node support for everything below Node 14 when I eagerly updated all the dependencies a while ago. So sorry about that. 

The support for Node >=6 is now back, and I've also included tests for all main Node versions List.js supports (6,8,10,12,14).