### PR TITLE
Update Carbon Ad Code

### DIFF
--- a/docs/_includes/carbon.html
+++ b/docs/_includes/carbon.html
@@ -1,1 +1,1 @@
-<script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?zoneid=1673&serve=C6AILKT&placement=listjscom" id="_carbonads_js"></script>
+<script async type="text/javascript" src="//cdn.carbonads.com/carbon.js?serve=CKYIKK7W&placement=listjscom" id="_carbonads_js"></script>


### PR DESCRIPTION
Replace legacy placement name based identifier to zone key identifier. We will discontinue the legacy identifier soon. You can check the latest ad code from sell.buysellads.com