### PR TITLE
Prevent pagination buttons from scrolling to top

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -92,6 +92,7 @@ module.exports = function (list) {
     })
 
     events.bind(pagingList.listContainer, 'click', function (e) {
+      e.preventDefault();
       var target = e.target || e.srcElement,
         page = list.utils.getAttribute(target, 'data-page'),
         i = list.utils.getAttribute(target, 'data-i')


### PR DESCRIPTION
Fixes a regression introduced by #499, causing the browser to scroll to 
the top of the page when the pagination buttons are clicked.