### PR TITLE
Fix pagination calculation by ensuring numeric data attributes

### DIFF
--- a/src/pagination.js
+++ b/src/pagination.js
@@ -93,11 +93,12 @@ module.exports = function (list) {
 
     events.bind(pagingList.listContainer, 'click', function (e) {
       var target = e.target || e.srcElement,
-        page = list.utils.getAttribute(target, 'data-page'),
-        i = list.utils.getAttribute(target, 'data-i')
-      if (i) {
-        list.show((i - 1) * page + 1, page)
+        page = parseInt(list.utils.getAttribute(target, 'data-page'), 10),
+        i = parseInt(list.utils.getAttribute(target, 'data-i'), 10)
+      if (isNaN(i) || isNaN(page)) {
+	return
       }
+      list.show((i - 1) * page + 1, page)
     })
 
     list.on('updated', function () {


### PR DESCRIPTION
## Description
Added proper type conversion for pagination-related data attributes that are retrieved as strings but need to be used as integers in calculations.

## Changes
- Added `parseInt()` with radix 10 to convert `data-page` attribute value to integer
- Added `parseInt()` with radix 10 to convert `data-i` attribute value to integer
- Added validation to ensure numeric values are valid before calculation

## Why
Previously, the pagination calculation was using string values directly from data attributes, which could lead to incorrect results when performing arithmetic operations. This change ensures proper numeric calculations.